### PR TITLE
Fix textarea background color style

### DIFF
--- a/src/components/textarea.js
+++ b/src/components/textarea.js
@@ -45,7 +45,7 @@ class AuTextarea extends HTMLElement {
 
         border: 0;
         outline: none;
-        background-color: var(--au-textarea-bg, 99.4% 0 0);
+        background-color: oklch(var(--au-textarea-bg, 99.4% 0 0));
         border-radius: var(--au-textarea-border-radius, 0.25rem);
         width: 100%;
         


### PR DESCRIPTION
## Summary
- fix background color style for `AuTextarea`

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb524f584832ca9d5dadea98f328f