### PR TITLE
Add focus test for file upload

### DIFF
--- a/test/file-upload.test.js
+++ b/test/file-upload.test.js
@@ -115,4 +115,13 @@ describe('<au-file-upload>', () => {
     expect(valid).to.be.false;
     expect(el.internals.validity.valueMissing).to.be.true;
   });
+
+  it('focuses hidden input when component is focused', async () => {
+    const el = await fixture(html`<au-file-upload></au-file-upload>`);
+    await el.updateComplete;
+
+    el.focus();
+
+    expect(document.activeElement).to.equal(el.fileInput);
+  });
 });


### PR DESCRIPTION
## Summary
- add regression test to ensure focus targets hidden file input

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb77317c8832c9c2c485aed747522