### PR TITLE
Fix focus target for file-upload

### DIFF
--- a/src/components/file-upload.js
+++ b/src/components/file-upload.js
@@ -418,7 +418,7 @@ class AuFileUpload extends HTMLElement {
   }
 
   focus() {
-    this.uploadButton.focus();
+    this.fileInput.focus();
   }
 
   get value() {


### PR DESCRIPTION
## Summary
- ensure file upload component focuses its hidden input when calling `focus`

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb93ef710832cafa1a661198acfca