### PR TITLE
Update breadcrumbs accessible name handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ Accesserty UI Kit focuses on making web components that comply with accessibilit
 - Usability Across Mainstream Frontend Frameworks: Accesserty UI Kit is developed with the principle of "copy and paste" usability to minimize the cost of creating accessible web pages, free from the pressures of version upgrades. Customization can be done independently if needed, though testing how to use Accesserty UI Kit across various mainstream frontend frameworks can be time-consuming.  
 
 
-## Demo  
+## Demo
 
-Please open html file found in each component folder to read more.  
+Please open html file found in each component folder to read more.
+
+For `<au-breadcrumbs>` the inner `<nav>` derives its accessible name from
+`aria-label`, `aria-labelledby`, or the `label` attribute, in that order.
 
 
 ## How to Use   

--- a/demo/breadcrumbs.html
+++ b/demo/breadcrumbs.html
@@ -52,6 +52,18 @@
           <td></td>
         </tr>
         <tr>
+          <td>aria-labelledby</td>
+          <td>References the id of an element that labels the breadcrumbs</td>
+          <td>string</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>label</td>
+          <td>Uses this value as aria-label when other labels are absent</td>
+          <td>string</td>
+          <td></td>
+        </tr>
+        <tr>
           <td>separator</td>
           <td>Sets the separator between breadcrumb items.</td>
           <td>string</td>
@@ -99,6 +111,25 @@
         ]'
       ></au-breadcrumbs>
       <p>open devtool you can see <code>&lt;nav aria-label="This is main navigator."&gt;</code></p>
+      <h2>aria-labelledby</h2>
+      <p>The <code>aria-labelledby</code> attribute can reference an element that labels the breadcrumbs.</p>
+      <div id="demo-label">Navigation heading</div>
+      <au-breadcrumbs
+        aria-labelledby="demo-label"
+        items='[
+          {
+            "text":"Home",
+            "url":"/"
+          },
+          {
+            "text":"About",
+            "url":"/about"
+          },
+          {
+            "text":"Contact"
+          }
+        ]'
+      ></au-breadcrumbs>
       <h2>Separator</h2>
       <au-breadcrumbs
         label="This is main navigator."
@@ -117,6 +148,7 @@
           }
         ]'
       ></au-breadcrumbs>
+      <p>The above example sets <code>label</code>. When no <code>aria-label</code> or <code>aria-labelledby</code> is provided, this value becomes the <code>aria-label</code> for the inner <code>&lt;nav&gt;</code>.</p>
       <h2>Custom Style</h2>
       <p>Set a classname and change CSS Variables.</p>
       <p>If you want to add an icon in front of an item, you can use slot="icon-{count}". For example, for the second one, use `slot="icon-2"`.</p>

--- a/src/components/breadcrumbs.js
+++ b/src/components/breadcrumbs.js
@@ -19,7 +19,15 @@ class AuBreadcrumbs extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ['id', 'class', 'aria-label', 'items', 'separator']
+    return [
+      'id',
+      'class',
+      'aria-label',
+      'aria-labelledby',
+      'label',
+      'items',
+      'separator'
+    ]
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
@@ -52,8 +60,19 @@ class AuBreadcrumbs extends HTMLElement {
     const id = this.getAttribute('id')
     const classname = this.getAttribute('class')
     const ariaLabel = this.getAttribute('aria-label')
+    const ariaLabelledby = this.getAttribute('aria-labelledby')
+    const labelAttr = this.getAttribute('label')
     const items = this.items // This should always be an array now
     const separator = this.getAttribute('separator') || '/'
+
+    let navAccessibleAttr = ''
+    if (ariaLabel !== null) {
+      navAccessibleAttr = `aria-label="${ariaLabel}"`
+    } else if (ariaLabelledby !== null) {
+      navAccessibleAttr = `aria-labelledby="${ariaLabelledby}"`
+    } else if (labelAttr !== null) {
+      navAccessibleAttr = `aria-label="${labelAttr}"`
+    }
 
     this.shadowRoot.innerHTML = `
       <style>
@@ -104,10 +123,10 @@ class AuBreadcrumbs extends HTMLElement {
           }
         }
       </style>
-      <nav 
+      <nav
         ${id !== null ? `id="` + id + `"` : ''}
         ${classname !== null ? `class="` + classname + `"` : ''}
-        ${ariaLabel !== null ? `aria-label="` + ariaLabel + `"` : ''}
+        ${navAccessibleAttr}
       >
         <ol>
           ${items

--- a/test/breadcrumbs.test.js
+++ b/test/breadcrumbs.test.js
@@ -84,4 +84,23 @@ describe("AuBreadcrumbs", () => {
     const slottedContent = iconSlot.assignedNodes()[0];
     expect(slottedContent.textContent).to.equal('icon');
   });
+
+  it('applies aria-labelledby when aria-label is absent', async () => {
+    const el = await fixture(html`
+      <div>
+        <span id="crumb-label">Breadcrumb navigation</span>
+        <au-breadcrumbs aria-labelledby="crumb-label"></au-breadcrumbs>
+      </div>
+    `);
+
+    const comp = el.querySelector('au-breadcrumbs');
+    const nav = comp.shadowRoot.querySelector('nav');
+    expect(nav.getAttribute('aria-labelledby')).to.equal('crumb-label');
+  });
+
+  it('uses label attribute as fallback aria-label', async () => {
+    const el = await fixture(html`<au-breadcrumbs label="My crumbs"></au-breadcrumbs>`);
+    const nav = el.shadowRoot.querySelector('nav');
+    expect(nav.getAttribute('aria-label')).to.equal('My crumbs');
+  });
 });


### PR DESCRIPTION
## Summary
- support `aria-labelledby` and `label` attributes in `<au-breadcrumbs>`
- document fallback accessible name logic in README and demo
- show accessible name options in `demo/breadcrumbs.html`
- test accessible name via `aria-label`, `aria-labelledby`, or `label`

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442c4cd9ec832c9517edb89abe46db