### PR TITLE
Fix file-upload disabled behavior

### DIFF
--- a/src/components/file-upload.js
+++ b/src/components/file-upload.js
@@ -159,7 +159,10 @@ class AuFileUpload extends HTMLElement {
 
     const triggerSlot = document.createElement('slot');
     triggerSlot.name = 'trigger';
-    triggerSlot.addEventListener('click', () => this.fileInput.click()); // 確保點擊會觸發 input
+    triggerSlot.addEventListener('click', () => {
+      if (this.hasAttribute('disabled')) return;
+      this.fileInput.click();
+    }); // 確保點擊會觸發 input
 
 
     this.dropZone = document.createElement('div');
@@ -194,13 +197,16 @@ class AuFileUpload extends HTMLElement {
 
     this.dropZone.addEventListener('dragover', e => {
       e.preventDefault();
+      if (this.hasAttribute('disabled')) return;
       this.dropZone.classList.add('dragover');
     });
     this.dropZone.addEventListener('dragleave', () => {
+      if (this.hasAttribute('disabled')) return;
       this.dropZone.classList.remove('dragover');
     });
     this.dropZone.addEventListener('drop', e => {
       e.preventDefault();
+      if (this.hasAttribute('disabled')) return;
       this.dropZone.classList.remove('dragover');
       const dt = e.dataTransfer;
       if (dt?.files) this.handleFiles(dt.files);
@@ -239,6 +245,7 @@ class AuFileUpload extends HTMLElement {
   _preventDefault = e => e.preventDefault();
 
   handleFiles(fileList) {
+    if (this.hasAttribute('disabled')) return;
     const maxTotalSizeMB = parseFloat(this.getAttribute('max-total-size-mb') || '20');
     const msgTotalSizeError = this.getAttribute('msg-total-size-error') || 'Total file size exceeds limit of';
     const msgTypeError = this.getAttribute('msg-type-error') || 'is not an accepted file type.';
@@ -360,6 +367,7 @@ class AuFileUpload extends HTMLElement {
       removeBtn.setAttribute('aria-label', `Remove ${file.name}`);
       removeBtn.setAttribute('part', 'delete');
       removeBtn.addEventListener('click', () => {
+        if (this.hasAttribute('disabled')) return;
         this.files = this.files.filter(f => f.name !== file.name || f.size !== file.size);
         this.updateFileList();
         this.updateUsage();
@@ -375,6 +383,7 @@ class AuFileUpload extends HTMLElement {
   }
 
   removeFile(file) {
+    if (this.hasAttribute('disabled')) return;
     this.files = this.files.filter(f => f.name !== file.name || f.size !== file.size);
     this.updateFileList();
     this.updateUsage();

--- a/test/file-upload.test.js
+++ b/test/file-upload.test.js
@@ -115,4 +115,25 @@ describe('<au-file-upload>', () => {
     expect(valid).to.be.false;
     expect(el.internals.validity.valueMissing).to.be.true;
   });
+
+  it('prevents adding or removing files when disabled', async () => {
+    const el = await fixture(html`<au-file-upload disabled></au-file-upload>`);
+    const file = new File(['a'], 'a.jpg', { type: 'image/jpeg' });
+
+    el.handleFiles([file]);
+    await el.updateComplete;
+    expect(el.files.length).to.equal(0);
+
+    el.removeAttribute('disabled');
+    el.handleFiles([file]);
+    await el.updateComplete;
+    expect(el.files.length).to.equal(1);
+
+    el.setAttribute('disabled', '');
+    await el.updateComplete;
+    const removeBtn = el.shadowRoot.querySelector('button.delete');
+    removeBtn.click();
+    await el.updateComplete;
+    expect(el.files.length).to.equal(1);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent files from being added or removed when `<au-file-upload>` is disabled
- guard drag/drop and trigger actions against disabled state
- test that disabling blocks add and remove actions

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450cf0b3bc832cbe8768e7a6f89aef