### PR TITLE
Fix remove button form submission

### DIFF
--- a/src/components/file-upload.js
+++ b/src/components/file-upload.js
@@ -362,6 +362,7 @@ class AuFileUpload extends HTMLElement {
       preview.appendChild(nameSpan);
 
       const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
       removeBtn.className = 'delete';
       removeBtn.textContent = this.getAttribute('msg-remove-text') || 'Remove';
       removeBtn.setAttribute('aria-label', `Remove ${file.name}`);


### PR DESCRIPTION
## Summary
- ensure delete button does not submit forms

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845108204cc832c911e2538fe050776