### PR TITLE
Add keyboard activation for file dialog

### DIFF
--- a/src/components/file-upload.js
+++ b/src/components/file-upload.js
@@ -164,6 +164,13 @@ class AuFileUpload extends HTMLElement {
       if (this.hasAttribute('disabled')) return;
       this.fileInput.click();
     }); // 確保點擊會觸發 input
+    triggerSlot.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+        e.preventDefault();
+        if (this.hasAttribute('disabled')) return;
+        this.fileInput.click();
+      }
+    }); // support non-button trigger accessibility
 
 
     this.dropZone = document.createElement('div');


### PR DESCRIPTION
## Summary
- open file dialog on `keydown` for file upload trigger slot

## Testing
- `npm test` *(fails: `web-test-runner: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684518e1d7f4832c80b26bd2d9455d7d