### PR TITLE
Add jump confirm button and aria-live feedback

### DIFF
--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -108,4 +108,26 @@ describe('AuPagination Web Component', () => {
     expect(input.max).to.equal('8');
     expect(input.min).to.equal('1');
   });
+
+  it('provides a confirm button for jump and emits page-change on click', async () => {
+    const el = await fixture(html`
+      <au-pagination
+        data-total="40"
+        data-page-size="10"
+        data-current-page="1"
+      ></au-pagination>
+    `);
+
+    let detail;
+    el.addEventListener('page-change', e => (detail = e.detail));
+
+    const input = el.shadowRoot.querySelector('input[type="number"]');
+    const btn = el.shadowRoot.querySelector('.au-pagination-group button');
+    input.value = '3';
+    btn.click();
+    await el.updateComplete;
+
+    expect(detail).to.equal(3);
+    expect(el.getAttribute('data-current-page')).to.equal('3');
+  });
 });


### PR DESCRIPTION
## Summary
- enhance pagination accessibility by announcing page changes
- add confirm button in jump section
- update styles for hidden live region
- test new button behaviour

## Testing
- `npm test` *(fails: web-test-runner not found)*

------
https://chatgpt.com/codex/tasks/task_e_684727b6bfcc832cbf476af58b8dbd78